### PR TITLE
Updated Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
 # ChangeLog
 
+# 24-Jul-2020
+
++ Added upstream flag (`--upstream_port`) to configure xDS server [d0d86bfdba05405700836858d480b4d730b18eff]


### PR DESCRIPTION
Apolz was not able to do this concurrent with the PR because they were created in parallel.

In future, encourage authors to update the [CHANGELOG](./CHANGELOG.md) when they submit PRs.